### PR TITLE
fix #11 Provide valid default for "favorites.ownExplorer"

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
                 },
                 "favorites.ownExplorer": {
                     "type": "boolean",
-                    "default": "false",
+                    "default": false,
                     "markdownDescription": "Specifies if the _Favorites_ view should be placed in its own explorer (on activity bar) or in the root Explorer."
                 }
             }


### PR DESCRIPTION
The default was incorrectly specified as a string in package.json